### PR TITLE
fixing for usage with cocoapods 'use_frameworks!'

### DIFF
--- a/NODE/NODE.h
+++ b/NODE/NODE.h
@@ -16,4 +16,4 @@ FOUNDATION_EXPORT const unsigned char NODEVersionString[];
 
 // In this header, you should import all the public headers of your framework using statements like #import <NODE/PublicHeader.h>
 
-#import <NODE/NSObject+NODE.h>
+#import <NODE_/NSObject+NODE.h>


### PR DESCRIPTION
Since the pod is called NODE_, the framework version will also be called NODE_
so the import needs to reflect it

related to: https://github.com/markohlebar/BIND/pull/29
